### PR TITLE
asciimath: Fix parsing of multiple quoted strings in same expression

### DIFF
--- a/py_asciimath/grammar/asciimath_grammar.py
+++ b/py_asciimath/grammar/asciimath_grammar.py
@@ -45,7 +45,7 @@ asciimath_grammar = r"""
     !_u: {} // unary functions
     !_asciimath1: {}
     !_asciimath2: {}
-    QS: "\"" /(?<=").+(?=")/ "\"" // Quoted String
+    QS: "\"" /(?<=").+?(?=")/ "\"" // Quoted String
 """.format(
     alias_string(left_parenthesis, alias=False),
     alias_string(right_parenthesis, alias=False),


### PR DESCRIPTION
Previously `"hello" + "world"` would be translated to latex as:
```latex
\text{hello" + "world}
```
as opposed to the correct form:
```latex
\text{hello} + \text{world}
```